### PR TITLE
Let Dependabot care about actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,9 @@ updates:
     interval: daily
     time: "09:00"
   open-pull-requests-limit: 10
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "09:00"
+  open-pull-requests-limit: 10


### PR DESCRIPTION
There are such a thing as an outdated action.

🙊 `actions/checkout`